### PR TITLE
Version 3.7

### DIFF
--- a/Extensions/Vendor_Ark/vendorark.lua
+++ b/Extensions/Vendor_Ark/vendorark.lua
@@ -1,6 +1,34 @@
 local AddonName = select(1, ...);
 local Addon  = select(2, ...);
 
+-- This will register a callback to Ark with Vendor
+local function registerArkExtension()
+    local arkExtension =
+    {
+        -- Vendor will check this source is loaded prior to registration.
+        -- It will also be displayed in the Vendor UI.
+        Source = "ArkInventory",
+        Addon = AddonName,
+
+        -- This is called by Vendor whenever its rules change and Ark needs to redo its classification of items into buckets.
+        OnRuleUpdate = function()
+            assert(ArkInventory and ArkInventory.ItemCacheClear and ArkInventory.Frame_Main_Generate)
+            -- Clear the Ark Inventory item cache, becuase this also caches rule results, which are now invalid becuase our rules changed.
+            ArkInventory.ItemCacheClear()
+            -- After clearing the cache we need to redraw the main window.
+            ArkInventory.Frame_Main_Generate(nil, ArkInventory.Const.Window.Draw.Recalculate)
+        end
+    }
+
+    assert(Vendor and Vendor.RegisterExtension, "Vendor RegisterExtension not found, cannot register extension: "..tostring(arkExtension.Source))
+    if (not Vendor:RegisterExtension(arkExtension)) then
+        -- something went wrong
+    end
+end
+registerArkExtension()
+
+-- The following is the plugin to Ark itself to add a function that runs vendor rules against an item Ark is evaluating.
+
 -- Checks if an item is auto-sold by vendor
 function Addon:Vendor_AutoSell()
     local fn = "Vendor_AutoSell";
@@ -17,29 +45,12 @@ function Addon:Vendor_AutoSell()
     return false;
 end
 
--- Checks to see if the provided item is scrap (according to scrap rules)
-function Addon:Vendor_AutoScrap()
-    local fn = "Vendor_AutoScrap";
-    local object = ArkInventoryRules.Object;
-    if (not object.h or (object.class ~= "item")) then
-        return;
-    end
-
-    local item = Vendor:GetItemProperties(GameTooltip, object.h);
-    if (item) then
-        local rm = Vendor:GetRuleManager();
-        return rm:CheckForScrap(item);
-    end
-
-    return false;
-end
-
-
 if (ArkInventoryRules and Vendor) then
-print("--> registering vendor extensions");
     local rules = ArkInventoryRules:NewModule(AddonName);
     function rules:OnEnable()
         ArkInventoryRules.Register(self, "vensell", Addon.Vendor_AutoSell);
-        ArkInventoryRules.Register(self, "venscrap", Addon.Vendor_AutoScrap);
     end;
 end
+
+
+

--- a/Extensions/Vendor_Ark/vendorark.lua
+++ b/Extensions/Vendor_Ark/vendorark.lua
@@ -31,13 +31,15 @@ registerArkExtension()
 
 -- Checks if an item is auto-sold by vendor
 function Addon:Vendor_AutoSell()
-    local fn = "Vendor_AutoSell";
+    assert(ArkInventory and ArkInventory.API.InternalIdToBlizzardBagId)
     local object = ArkInventoryRules.Object;
-    if (not object.h or (object.class ~= "item")) then
+    if (not object or not object.loc_id or not object.bag_id or not object.slot_id) then
         return;
     end
 
-    local item = Vendor:GetItemProperties(GameTooltip, object.h);
+    -- Becuase Ark is on another planet and has its own concept of bags, must convert to blizzard bags.
+    local bag = ArkInventory.API.InternalIdToBlizzardBagId( object.loc_id, object.bag_id )
+    local item = Vendor:GetItemProperties(bag, object.slot_id)
     if (item) then
         return Vendor:EvaluateItemForSelling(item);
     end

--- a/rules/evaluate.lua
+++ b/rules/evaluate.lua
@@ -10,8 +10,6 @@ function Addon:EvaluateItemForSelling(item)
         return false, nil, nil
     end
 
-    -- If have not yet initialized, or the config has changed we need to build our list of "keep" rules
-    -- we always add the check against the neversell list no matter what the options says
     if (not self.ruleManager) then
         self.ruleManager = Addon.RuleManager:Create();
     end

--- a/rules/functions.lua
+++ b/rules/functions.lua
@@ -227,7 +227,6 @@ function Addon.RuleFunctions.HasStat(...)
             (type(stat) == "string") and 
             string.len(stat) and 
             itemStats[stat]) then
-            print("item has ", stat);
             return true;
         end
     end

--- a/rules/functions.lua
+++ b/rules/functions.lua
@@ -210,7 +210,7 @@ function Addon.RuleFunctions.HasStat(...)
     local itemStats = {};
 
     -- build a table of the stats this item has
-    for st, sv in pairs(GetItemStats(string.format("item:%d", Id))) do
+    for st, sv in pairs(GetItemStats(Link)) do
         if (sv ~= 0) then
             itemStats[_G[st]] = true;
         end

--- a/sys/config.lua
+++ b/sys/config.lua
@@ -19,7 +19,7 @@ local function IsMigrationToShadowlands()
     local ver = tonumber(select(4, GetBuildInfo()));
     local currV = tonumber(Vendor_RulesConfig.interfaceversion);
 
-    if ((ven >= 90000) and (currV < 90000)) then
+    if ((ver >= 90000) and (currV < 90000)) then
         Addon:Print("---> Migration to ShadowLands");
         return true;
     end
@@ -255,6 +255,16 @@ end
 
 
 --*****************************************************************************
+-- Called to signal changes in the config explicitly.
+--*****************************************************************************
+function Addon.Config:NotifyChanges()
+    Addon:Debug("Notifying Changes")
+    self.changes = true
+    self:notifyChanges()
+end
+
+
+--*****************************************************************************
 -- Returns the configuration value with the specified name, if we cannot find
 -- the specified value then 'nil' is returned
 --
@@ -397,7 +407,6 @@ end
 function Addon:GetConfig()
     if (not self.config) then
         self.config = Addon.Config:Create()
-        self.config:AddOnChanged(function() self:ClearTooltipResultCache() end)
     end
     return self.config
 end

--- a/sys/init.lua
+++ b/sys/init.lua
@@ -8,7 +8,6 @@
 -- or it means someone else already defined the namespace, and we're in Undefined Behavior land.
 local AddonName = select(1,...)
 
-print(...);
 if _G[AddonName] or _G[AddonName.."_GET"] or _G[AddonName.."_LOC"] then
     assert(false, "Addon conflict detected. Addon already exists with this name: "..AddonName)
 end

--- a/ui/tooltip.lua
+++ b/ui/tooltip.lua
@@ -44,12 +44,16 @@ local ruleName = nil
 
 -- Forcibly clear the cache, used when Blocklist or rules change to force a re-evaluation and update the tooltip.
 function Addon:ClearTooltipResultCache()
+    Addon:Debug("Clearing tooltip result cache")
     itemLink = nil
     willBeSold = nil
     blocklist = nil
     ruleId = nil
     ruleName = nil
 end
+
+Config:AddOnChanged(Addon.ClearTooltipResultCache)
+
 
 function Addon:AddItemTooltipLines(tooltip, link)
     -- Check Cache if we already have data for this item from a previous update.

--- a/ui/tooltip.lua
+++ b/ui/tooltip.lua
@@ -44,7 +44,6 @@ local ruleName = nil
 
 -- Forcibly clear the cache, used when Blocklist or rules change to force a re-evaluation and update the tooltip.
 function Addon:ClearTooltipResultCache()
-    Addon:Debug("Clearing tooltip result cache")
     itemLink = nil
     willBeSold = nil
     blocklist = nil

--- a/vendor/blocklists.lua
+++ b/vendor/blocklists.lua
@@ -1,4 +1,4 @@
-local Addon, L = _G[select(1,...).."_GET"]()
+local Addon, L, Config = _G[select(1,...).."_GET"]()
 
 -- Manages the always-sell and never-sell blocklists.
 -- Consider - adding "toggle" as a method on config can (and should) fire a config change.
@@ -23,17 +23,19 @@ function Addon:ToggleItemInBlocklist(list, item)
     local id = self:GetItemId(item)
     if not id then return nil end
 
-    local config = self:GetConfig()
-
     -- Add it to the specified list.
     -- If it already existed, remove it from that list.
     if list == self.c_AlwaysSellList then
-        local ret = toggle(config:GetValue("sell_always"), config:GetValue("sell_never"), id)
-        if (ret) then self:ClearTooltipResultCache() end
+        local ret = toggle(Config:GetValue("sell_always"), Config:GetValue("sell_never"), id)
+        if (ret) then
+            Config:NotifyChanges()
+        end
         return ret
     elseif list == self.c_NeverSellList then
-        local ret = toggle(config:GetValue("sell_never"), config:GetValue("sell_always"), id)
-        if (ret) then  self:ClearTooltipResultCache() end
+        local ret = toggle(Config:GetValue("sell_never"), Config:GetValue("sell_always"), id)
+        if (ret) then
+            Config:NotifyChanges()
+        end
         return ret
     else
         return nil


### PR DESCRIPTION
Lots of fixes here.
* New HasStat() function, e.g.: HasStat("Speed") will be true if the item has Speed on it. Many options here.
* Several fixes for ArkInventory plugin to refresh Ark whenever any rule state changes. Ark will no properly re-bucket items as their rule evaluations change instead of being in a stale cache.
* New plugin functionality to have a callback on Vendor rule changes
* Fix blocklists to properly signal update for callbacks when changed.